### PR TITLE
Add reproducible j0126 Zebrafinch ABISS replay

### DIFF
--- a/scripts/run_seuron_provenance.py
+++ b/scripts/run_seuron_provenance.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Sequence
@@ -31,6 +31,7 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from connectomics.runtime.abiss_chunk import (  # noqa: E402
+    STAGE_CHOICES,
     OutputLayerSpec,
     PreparedConfig,
     RunResult,
@@ -768,7 +769,11 @@ def _preflight_affinity(
     return metadata
 
 
-def execute_replay(resolved: ResolvedReplay) -> RunResult:
+def execute_replay(
+    resolved: ResolvedReplay,
+    *,
+    stages: Sequence[str] | None = None,
+) -> RunResult:
     """Preflight, enforce namespace safety, write a manifest, and run ABISS."""
 
     _preflight_abiss(resolved)
@@ -782,10 +787,10 @@ def execute_replay(resolved: ResolvedReplay) -> RunResult:
         expected_manifest = _expected_manifest(resolved, abiss_build_id=build_id)
         _apply_output_mode(resolved, expected_manifest)
         _write_manifest(resolved, expected_manifest)
-        return run_abiss_chunk(
-            prepare_execution(resolved, affinity_metadata),
-            execute=True,
-        )
+        prepared = prepare_execution(resolved, affinity_metadata)
+        if stages is not None:
+            prepared = replace(prepared, stages=tuple(stages))
+        return run_abiss_chunk(prepared, execute=True)
 
 
 def _resolution_report(resolved: ResolvedReplay, *, execute: bool) -> dict[str, Any]:
@@ -849,6 +854,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Run ABISS after preflight; omission performs a pure resolve",
     )
+    parser.add_argument(
+        "--stages",
+        nargs="+",
+        choices=STAGE_CHOICES,
+        default=None,
+        help="ABISS stages to run during execution (default: the complete pipeline)",
+    )
     return parser.parse_args(argv)
 
 
@@ -861,7 +873,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         if not args.execute:
             return 0
-        result = execute_replay(resolved)
+        result = execute_replay(resolved, stages=args.stages)
     except (OSError, RuntimeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/tutorials/neuron_j0126/README.md
+++ b/tutorials/neuron_j0126/README.md
@@ -6,6 +6,10 @@ This tutorial turns a 10 nm j0126 EM volume into a neuron segmentation in three 
 2. Decode them conservatively with ABISS, preferring splits to false merges.
 3. Reconnect only high-confidence, morphologically continuous branches.
 
+For the frozen PyTC2 Zebrafinch replay, including fail-closed input checks and
+non-interactive Slurm submission, follow the
+[reproduction guide](reproduction/README.md).
+
 The last step is prediction-only at runtime. It uses the segmentation, affinities, predicted morphology, and an external nucleus-instance manifest; it does not read evaluation skeletons, their lookup table, or an FFN segmentation.
 
 ## Results

--- a/tutorials/neuron_j0126/reproduction/README.md
+++ b/tutorials/neuron_j0126/reproduction/README.md
@@ -1,0 +1,153 @@
+# Reproduce the frozen j0126 Zebrafinch decode
+
+This directory replays the two ABISS rows used by the PyTC2 j0126 ablation:
+
+1. conservative decoding with a tissue-border exclusion mask; and
+2. the same decode with nucleus-instance competition enabled.
+
+The workflow reuses an existing three-channel affinity prediction. It does not
+train a network and does not read the test skeletons until the final evaluation
+job. All volume computation is submitted as non-interactive Slurm jobs.
+
+## Frozen inputs
+
+The replay requires:
+
+- the complete grid-indexed `float16` affinity store and its sibling
+  `.h5.index.json`;
+- the full-resolution tissue keep mask;
+- `yl_cb_80nm_neuron_v2.h5` for the nucleus-aware row;
+- the test-50 skeleton HDF5 only for evaluation; and
+- ABISS commit `452efa5f87f9d3cb241891ee44010d966a33b316`.
+
+The captured algorithmic parameters are in [seuron_provenance.json](seuron_provenance.json).
+Do not change the `BBOX`, resolution, chunk size, watershed thresholds, dust
+threshold, or agglomeration threshold for the frozen replay.
+
+## 1. Make run configs
+
+Copy [exclusion.example.yaml](exclusion.example.yaml),
+[nucleus.example.yaml](nucleus.example.yaml), and `seuron_provenance.json` to a
+writeable run-config directory. Replace every `/path/to` value. The two YAML
+files must use different output roots. Keep the affinity store in place; the
+workflow reads it but does not copy or modify it.
+
+Use a Python environment containing the PyTorch Connectomics runtime
+dependencies, CloudVolume, HDF5, NumPy, SciPy, NetworkX, PyYAML, and `em_erl`.
+Set `PYTHON` to that environment's interpreter in every command below.
+
+## 2. Build the frozen ABISS dependency
+
+Clone ABISS into the ignored `lib/` directory and pin it before submitting the
+build:
+
+```bash
+git clone https://github.com/PytorchConnectomics/ABISS.git lib/abiss
+git -C lib/abiss checkout 452efa5f87f9d3cb241891ee44010d966a33b316
+
+sbatch --export=ALL,REPOSITORY="$PWD",ABISS_HOME="$PWD/lib/abiss",PYTC_PREFIX=/path/to/conda/env \
+  tutorials/neuron_j0126/reproduction/slurm/00_build_abiss.sbatch
+```
+
+`PYTC_PREFIX` supplies Boost headers and libraries. The job builds `ws` and
+`agg`, then runs all three ABISS tests. Record the successful job ID.
+
+## 3. Run fail-closed preflight
+
+Submit [01_preflight.sbatch](slurm/01_preflight.sbatch) after the build. Its
+required environment variables are listed at the top of that script. Preflight
+checks the exact ABISS commit, all 726 affinity chunks and edge reads, the keep
+mask and nucleus shapes, the test skeleton file, and available output capacity.
+It writes a machine-readable JSON report and exits nonzero on any mismatch.
+
+## 4. Run the ABISS runtime smoke test
+
+Use [02_smoke.sbatch](slurm/02_smoke.sbatch) with an exclusion-only smoke YAML.
+A cropped run cannot use the frozen full-volume `AFF_KEEP_MASK` with this HDF5
+chunk backend, so omit that field in the smoke config. The default is one
+origin-anchored native ABISS chunk (512×512×256). It checks input decoding,
+the frozen watershed binary, remapping, and output writing.
+
+The exact frozen ABISS commit cannot complete a representative cropped replay:
+nonzero origins and cropped multi-chunk hierarchies produce watershed IDs that
+lack the full-volume global RAG namespace expected by later mean-edge
+processing. A nucleus crop can validate scan/competition and write its
+manifest, but `agg` then fails closed on the unmatched ID. Therefore the
+single-chunk watershed smoke is only a runtime check; use the regression
+evaluation of the existing frozen full nucleus result as the semantic gate,
+then run the fresh full-volume configs. Do not remove `AFF_KEEP_MASK` or change
+`ABISS_NUC_MIN_TAGGED: 1024` in either full-volume config.
+
+## 5. Prepare and submit a full replay
+
+Preparation creates the precomputed output layers and deterministic ABISS task
+lists but does not run chunks:
+
+```bash
+RUN_ROOT=/path/to/run/exclusion
+RUNTIME_JSON="$RUN_ROOT/runtime.json"
+
+sbatch --export=ALL,REPOSITORY="$PWD",PYTHON=/path/to/python,CONFIG=/path/to/exclusion.yaml,OUT_ROOT="$RUN_ROOT",RUN_NAME=abiss_exclusion_frozen,RUNTIME_JSON="$RUNTIME_JSON" \
+  --output="$RUN_ROOT/prepare_%j.out" \
+  tutorials/neuron_j0126/reproduction/slurm/03_prepare_full.sbatch
+```
+
+After that job succeeds, submit the dependency graph:
+
+```bash
+RUNTIME_JSON="$RUNTIME_JSON" \
+RUN_ROOT="$RUN_ROOT" \
+PYTHON=/path/to/python \
+ABISS_LIBRARY_PREFIX=/path/to/conda/env \
+SKELETONS=/path/to/test_50_skeletons.h5 \
+JOB_PREFIX=zf-exclusion \
+PARTITION=medium \
+bash tutorials/neuron_j0126/reproduction/submit_full.sh
+```
+
+The wrapper submits watershed and mean-edge arrays with `afterok`
+dependencies, followed by a short evaluation job. The nucleus config inserts a
+single high-memory nucleus-competition job on `long` between watershed remap
+and agglomeration. `submission.tsv`, `final_decode_jobid.txt`, and
+`evaluation_jobid.txt` record the complete graph. To serialize the second run,
+set `INIT_DEP` to the first run's final decode job ID.
+
+## 6. Check outputs and compare metrics
+
+The final segmentation is the local precomputed directory named by `SEG_PATH`
+inside `runtime.json`. `evaluation.json` reports NERL at strict `mt=0` and
+five-node tolerance `mt=5`, plus background-inclusive and foreground-only
+skeleton-node VOI.
+
+The frozen targets are:
+
+| Decode | NERL mt=0 | NERL mt=5 | VOI split | VOI merge | VOI sum |
+|---|---:|---:|---:|---:|---:|
+| Exclusion | 0.267679 | 0.469513 | 2.542 | 0.042 | 2.584 |
+| Nucleus-aware | 0.287184 | 0.481614 | 2.542840 | 0.019130 | 2.561970 |
+
+Treat deviations larger than normal floating-point rounding as a reproduction
+failure and inspect the manifest, ABISS build ID, input hashes, and node
+coverage before tuning anything.
+
+The same evaluator accepts the canonical FFN graph-order node LUT instead of a
+volume. Set `NODE_LUT` rather than `SEGMENTATION` when submitting
+`05_evaluate.sbatch`. It sorts numeric skeleton IDs exactly as the `em_erl` LUT
+generator does. The canonical reference reproduces `NERL mt=0 0.525766`,
+`NERL mt=5 0.538003`, and background-inclusive `VOI 1.855795`.
+
+The canonical LUT is a matched native/mip0 sample. This was verified by
+regenerating all 500,845 node assignments from the public FFN CloudVolume with
+`--mip 0`: the regenerated file was byte-identical to the canonical artifact
+(`sha256 744c7ee42bbae97234b386756f0b91453f9839ba5cd4658f740b45a439ada1c2`)
+and reproduced the metrics above exactly. The restartable Slurm entry point
+[05_ffn_native_lut.sbatch](slurm/05_ffn_native_lut.sbatch) performs that
+provenance check. It uses a persistent CloudVolume cache, writes the mip0 LUT
+and SHA-256, and evaluates it unchanged with the same public evaluator.
+
+## Restart behavior
+
+Every Slurm edge uses `afterok`, so a failed stage prevents downstream jobs
+from running. Inspect its log, fix the cause, and prepare a new output namespace
+for a clean replay. Use `--mode resume` only when the existing manifest matches
+the exact inputs and ABISS runtime identity; the replay code rejects mismatches.

--- a/tutorials/neuron_j0126/reproduction/README.md
+++ b/tutorials/neuron_j0126/reproduction/README.md
@@ -49,16 +49,42 @@ sbatch --export=ALL,REPOSITORY="$PWD",ABISS_HOME="$PWD/lib/abiss",PYTC_PREFIX=/p
   tutorials/neuron_j0126/reproduction/slurm/00_build_abiss.sbatch
 ```
 
-`PYTC_PREFIX` supplies Boost headers and libraries. The job builds `ws` and
-`agg`, then runs all three ABISS tests. Record the successful job ID.
+`PYTC_PREFIX` must contain the conda cross-compiler, Boost 1.82, and oneTBB.
+The job pins all four CMake selections explicitly, enables the required
+`EXTRACT_SIZE=ON` compile definition, and rejects binaries linked to legacy
+`libtbb.so.2` or Boost 1.85. `EXTRACT_SIZE` is not optional for this workflow:
+without it, `acme` writes empty supervoxel-size files and `agg` fails on an
+incomplete RAG. The job then builds `ws` and `agg`, runs all three ABISS tests,
+prints the binary hashes and dynamic dependencies, and records those details
+in the Slurm log. Use a new checkout when changing toolchains; a stale CMake
+build directory is not a reproducible rebuild.
+
+If a previous full replay reached watershed but failed in mean-edge
+agglomeration, validate the replacement binary on one preserved failed chunk
+before launching another full volume:
+
+```bash
+sbatch --export=ALL,\
+SOURCE_CHUNK=/path/to/failed/work/0_2_2_8,\
+VALIDATION_DIR=/path/to/new/agg-regression,\
+ABISS_HOME="$PWD/lib/abiss",\
+ABISS_LIBRARY_PREFIX=/path/to/conda/env \
+  tutorials/neuron_j0126/reproduction/slurm/00_validate_agg.sbatch
+```
+
+The check copies the preserved raw chunk inputs, regenerates the RAG and size
+maps with the replacement `acme`, never modifies the failed run, and writes
+`SUCCESS` only after `agg` produces nonempty residual RAG and remap outputs.
 
 ## 3. Run fail-closed preflight
 
-Submit [01_preflight.sbatch](slurm/01_preflight.sbatch) after the build. Its
+Submit [01_preflight.sbatch](slurm/01_preflight.sbatch) after the build, with
+`PYTC_PREFIX` set to the same environment used by the build. Its
 required environment variables are listed at the top of that script. Preflight
-checks the exact ABISS commit, all 726 affinity chunks and edge reads, the keep
-mask and nucleus shapes, the test skeleton file, and available output capacity.
-It writes a machine-readable JSON report and exits nonzero on any mismatch.
+checks the exact ABISS commit and compiler/Boost/TBB identity, binary dynamic
+dependencies, all 726 affinity chunks and edge reads, the keep mask and nucleus
+shapes, the test skeleton file, and available output capacity. It writes a
+machine-readable JSON report and exits nonzero on any mismatch.
 
 ## 4. Run the ABISS runtime smoke test
 

--- a/tutorials/neuron_j0126/reproduction/evaluate.py
+++ b/tutorials/neuron_j0126/reproduction/evaluate.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Evaluate a native j0126 precomputed segmentation at test-50 skeleton nodes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+REPOSITORY = Path(__file__).resolve().parents[3]
+if str(REPOSITORY) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY))
+
+from connectomics.metrics.nerl import (
+    extract_nerl_score_outputs,
+    import_em_erl,
+    skeleton_voi,
+)
+
+
+def _load_graph(skeleton_path: Path) -> tuple[Any, np.ndarray]:
+    import_em_erl()
+    from em_erl import skel_to_erlgraph
+
+    class Skeleton:
+        pass
+
+    skeletons = {}
+    with h5py.File(skeleton_path, "r", locking=False) as handle:
+        for key in sorted(handle.keys(), key=lambda value: int(value)):
+            skeleton = Skeleton()
+            skeleton.vertices = handle[key]["vertices"][:].astype(np.int64)
+            skeleton.edges = handle[key]["edges"][:].astype(np.int64)
+            skeletons[int(key)] = skeleton
+    graph = skel_to_erlgraph(skeletons)
+    positions_xyz = np.concatenate(
+        [skeletons[int(identifier)].vertices[:, ::-1] for identifier in graph.skeleton_id],
+        axis=0,
+    )
+    if positions_xyz.shape[0] != int(graph.num_nodes):
+        raise RuntimeError("Skeleton-node order does not match the ERL graph")
+    return graph, positions_xyz
+
+
+def _sample_node_lut(
+    segmentation: Path,
+    positions_xyz: np.ndarray,
+    *,
+    resolution_xyz: tuple[int, int, int],
+    read_chunk_xyz: tuple[int, int, int],
+) -> np.ndarray:
+    from cloudvolume import CloudVolume
+
+    volume = CloudVolume(
+        segmentation.as_uri(),
+        mip=list(resolution_xyz),
+        fill_missing=True,
+        bounded=False,
+        progress=False,
+    )
+    chunk = np.asarray(read_chunk_xyz, dtype=np.int64)
+    groups: dict[tuple[int, ...], list[int]] = defaultdict(list)
+    for index, chunk_index in enumerate(positions_xyz // chunk):
+        groups[tuple(int(value) for value in chunk_index)].append(index)
+
+    lut = np.zeros(positions_xyz.shape[0], dtype=np.uint64)
+    for chunk_index, node_indices in groups.items():
+        origin = np.asarray(chunk_index, dtype=np.int64) * chunk
+        stop = origin + chunk
+        block = np.asarray(
+            volume[
+                origin[0] : stop[0],
+                origin[1] : stop[1],
+                origin[2] : stop[2],
+            ]
+        )
+        if block.ndim == 4:
+            block = block[..., 0]
+        indices = np.asarray(node_indices, dtype=np.int64)
+        local = positions_xyz[indices] - origin
+        in_bounds = np.all((local >= 0) & (local < np.asarray(block.shape)), axis=1)
+        if np.any(in_bounds):
+            query = local[in_bounds]
+            lut[indices[in_bounds]] = block[query[:, 0], query[:, 1], query[:, 2]]
+    return lut
+
+
+def _score(graph: Any, lut: np.ndarray, merge_threshold: int) -> dict[str, Any]:
+    _, compute_erl_score, _ = import_em_erl()
+    score = compute_erl_score(graph, lut, None, merge_threshold=merge_threshold)
+    score.compute_erl()
+    pred_erl, gt_erl, num_skeletons, _ = extract_nerl_score_outputs(score)
+    return {
+        "merge_threshold": merge_threshold,
+        "nerl": float(pred_erl / gt_erl),
+        "pred_erl": float(pred_erl),
+        "gt_erl": float(gt_erl),
+        "num_skeletons": int(num_skeletons),
+    }
+
+
+def _parse_triplet(value: str) -> tuple[int, int, int]:
+    parsed = tuple(int(item) for item in value.split(","))
+    if len(parsed) != 3:
+        raise argparse.ArgumentTypeError("expected three comma-separated integers")
+    return parsed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--segmentation", type=Path)
+    source.add_argument(
+        "--node-lut",
+        type=Path,
+        help="existing graph-order node-to-segment LUT, for example the canonical FFN LUT",
+    )
+    parser.add_argument("--skeletons", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--resolution-xyz", type=_parse_triplet, default=(9, 9, 20))
+    parser.add_argument("--read-chunk-xyz", type=_parse_triplet, default=(256, 256, 256))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    graph, positions_xyz = _load_graph(args.skeletons)
+    if args.node_lut is not None:
+        from em_erl import load_node_segment_lut
+
+        lut = np.asarray(load_node_segment_lut(args.node_lut), dtype=np.uint64)
+        if lut.shape != (positions_xyz.shape[0],):
+            raise RuntimeError(
+                f"node LUT has shape {lut.shape}; expected {(positions_xyz.shape[0],)}"
+            )
+    else:
+        lut = _sample_node_lut(
+            args.segmentation,
+            positions_xyz,
+            resolution_xyz=args.resolution_xyz,
+            read_chunk_xyz=args.read_chunk_xyz,
+        )
+    foreground = lut != 0
+    gt_labels = np.asarray(graph.node_skeleton_index, dtype=np.uint64) + 1
+    voi_split, voi_merge, voi_sum = skeleton_voi(lut, gt_labels)
+    fg_split, fg_merge, fg_sum = skeleton_voi(lut[foreground], gt_labels[foreground])
+    owners: dict[int, set[int]] = defaultdict(set)
+    for label, skeleton_index in zip(
+        lut[foreground], np.asarray(graph.node_skeleton_index)[foreground]
+    ):
+        owners[int(label)].add(int(skeleton_index))
+    multi_owner_labels = [label for label, values in owners.items() if len(values) > 1]
+    multi_owner_nodes = (
+        np.isin(lut, multi_owner_labels)
+        if multi_owner_labels
+        else np.zeros(lut.shape, dtype=bool)
+    )
+    fragments_per_skeleton = []
+    dominant_fraction_per_skeleton = []
+    for skeleton_index in range(int(graph.num_skeletons)):
+        skeleton_labels = lut[np.asarray(graph.node_skeleton_index) == skeleton_index]
+        labels, counts = np.unique(skeleton_labels[skeleton_labels != 0], return_counts=True)
+        fragments_per_skeleton.append(int(labels.size))
+        dominant_fraction_per_skeleton.append(
+            float(counts.max() / skeleton_labels.size) if counts.size else 0.0
+        )
+    report = {
+        "segmentation": str(args.segmentation) if args.segmentation is not None else None,
+        "node_lut": str(args.node_lut) if args.node_lut is not None else None,
+        "skeletons": str(args.skeletons),
+        "coordinate_order": "skeleton ZYX; segmentation XYZ",
+        "edge_length_units": "native voxels",
+        "nodes": int(lut.size),
+        "node_coverage": float(np.mean(foreground)),
+        "unique_foreground_labels": int(np.unique(lut[foreground]).size),
+        "multi_owner_labels": len(multi_owner_labels),
+        "multi_owner_node_fraction": float(np.mean(multi_owner_nodes)),
+        "mean_fragments_per_skeleton": float(np.mean(fragments_per_skeleton)),
+        "median_dominant_label_fraction": float(
+            np.median(dominant_fraction_per_skeleton)
+        ),
+        "nerl": {
+            "mt0": _score(graph, lut, 0),
+            "mt5": _score(graph, lut, 5),
+        },
+        "voi_background_inclusive": {
+            "split": voi_split,
+            "merge": voi_merge,
+            "sum": voi_sum,
+        },
+        "voi_foreground_only": {
+            "split": fg_split,
+            "merge": fg_merge,
+            "sum": fg_sum,
+            "nodes": int(np.count_nonzero(foreground)),
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tutorials/neuron_j0126/reproduction/exclusion.example.yaml
+++ b/tutorials/neuron_j0126/reproduction/exclusion.example.yaml
@@ -1,0 +1,16 @@
+# Copy this file outside the checkout and replace every /path/to placeholder.
+# The affinity store is reused in place; it is never copied into output_root.
+seuron_replay:
+  provenance_path: seuron_provenance.json
+  backend: abiss_local
+  data: local
+  out_root: /path/to/writeable/j0126-reproduction/exclusion
+  name: abiss_exclusion_frozen
+  secrets_dir: /path/to/writeable/j0126-reproduction/.cloudvolume/secrets
+  abiss_home: /path/to/pytorch_connectomics/lib/abiss
+  aff_path: /path/to/existing/affinity.h5.chunks
+
+  param_overrides:
+    AFF_CONVENTION: banis
+    AFF_RESTORE_SIGMOID: 0.2
+    AFF_KEEP_MASK: /path/to/tissue_border_keep_mask_full.zarr

--- a/tutorials/neuron_j0126/reproduction/nucleus.example.yaml
+++ b/tutorials/neuron_j0126/reproduction/nucleus.example.yaml
@@ -1,0 +1,25 @@
+# Copy this file outside the checkout and replace every /path/to placeholder.
+seuron_replay:
+  provenance_path: seuron_provenance.json
+  backend: abiss_local
+  data: local
+  out_root: /path/to/writeable/j0126-reproduction/nucleus
+  name: abiss_nucleus_frozen
+  secrets_dir: /path/to/writeable/j0126-reproduction/.cloudvolume/secrets
+  abiss_home: /path/to/pytorch_connectomics/lib/abiss
+  aff_path: /path/to/existing/affinity.h5.chunks
+
+  param_overrides:
+    AFF_CONVENTION: banis
+    AFF_RESTORE_SIGMOID: 0.2
+    AFF_KEEP_MASK: /path/to/tissue_border_keep_mask_full.zarr
+
+    NUC_PATH: /path/to/yl_cb_80nm_neuron_v2.h5
+    NUC_RATIO: [4, 8, 8]
+    NUC_OFFSET: [0, 0, 0]
+    NUC_MIN_SHARE: 0.02
+    NUC_CONTACT_UM: 8.0
+    NUC_COMPETITION_MARGIN_ZYX: [1024, 1024, 512]
+    NUC_COMPETITION_FACTOR: 4
+    ABISS_NUC_DOMINANCE: 0.6
+    ABISS_NUC_MIN_TAGGED: 1024

--- a/tutorials/neuron_j0126/reproduction/preflight.py
+++ b/tutorials/neuron_j0126/reproduction/preflight.py
@@ -16,7 +16,6 @@ from typing import Any
 
 import h5py
 
-
 EXPECTED_ABISS_COMMIT = "452efa5f87f9d3cb241891ee44010d966a33b316"
 EXPECTED_BBOX_XYZ = (0, 0, 0, 10664, 10912, 5700)
 EXPECTED_INDEX_SHAPE_ZYX = (5700, 12288, 12288)
@@ -39,8 +38,7 @@ def _check_chunk(index_dir: Path, entry: dict[str, Any]) -> dict[str, Any]:
     if not path.is_file():
         raise FileNotFoundError(path)
     expected_spatial = tuple(
-        int(stop) - int(start)
-        for start, stop in zip(entry["start_zyx"], entry["stop_zyx"])
+        int(stop) - int(start) for start, stop in zip(entry["start_zyx"], entry["stop_zyx"])
     )
     with h5py.File(path, "r", locking=False) as handle:
         if "main" not in handle:
@@ -79,6 +77,31 @@ def _git_tracked_status(path: Path) -> str:
     return result.stdout.strip()
 
 
+def _cmake_cache(path: Path) -> dict[str, str]:
+    values = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith(("#", "//")) or "=" not in line:
+            continue
+        typed_key, value = line.split("=", 1)
+        key = typed_key.split(":", 1)[0]
+        values[key] = value
+    return values
+
+
+def _dynamic_dependencies(path: Path) -> list[str]:
+    result = subprocess.run(
+        ["readelf", "-d", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    dependencies = []
+    for line in result.stdout.splitlines():
+        if "(NEEDED)" in line and "[" in line and "]" in line:
+            dependencies.append(line.split("[", 1)[1].split("]", 1)[0])
+    return dependencies
+
+
 def _package_versions() -> dict[str, str]:
     versions = {}
     for distribution in (
@@ -105,6 +128,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--nucleus", type=Path, required=True)
     parser.add_argument("--skeletons", type=Path, required=True)
     parser.add_argument("--abiss-home", type=Path, required=True)
+    parser.add_argument("--pytc-prefix", type=Path, required=True)
     parser.add_argument("--storage-root", type=Path, required=True)
     parser.add_argument("--min-free-tib", type=float, default=8.0)
     parser.add_argument("--workers", type=int, default=8)
@@ -121,6 +145,7 @@ def main() -> int:
         args.nucleus,
         args.skeletons,
         args.abiss_home,
+        args.pytc_prefix,
         args.storage_root,
     ):
         if not path.exists():
@@ -128,9 +153,7 @@ def main() -> int:
 
     abiss_head = _git_head(args.abiss_home)
     if abiss_head != EXPECTED_ABISS_COMMIT:
-        raise RuntimeError(
-            f"ABISS is {abiss_head}; frozen result requires {EXPECTED_ABISS_COMMIT}"
-        )
+        raise RuntimeError(f"ABISS is {abiss_head}; frozen result requires {EXPECTED_ABISS_COMMIT}")
     tracked_status = _git_tracked_status(args.abiss_home)
     if tracked_status:
         raise RuntimeError(
@@ -141,6 +164,40 @@ def main() -> int:
         path = args.abiss_home / relative
         if not path.is_file():
             raise FileNotFoundError(f"ABISS runtime is incomplete: {path}")
+
+    expected_toolchain = {
+        "CMAKE_C_COMPILER": str(args.pytc_prefix / "bin" / "x86_64-conda-linux-gnu-cc"),
+        "CMAKE_CXX_COMPILER": str(args.pytc_prefix / "bin" / "x86_64-conda-linux-gnu-c++"),
+        "Boost_DIR": str(args.pytc_prefix / "lib" / "cmake" / "Boost-1.82.0"),
+        "TBB_DIR": str(args.pytc_prefix / "lib" / "cmake" / "TBB"),
+        "EXTRACT_SIZE": "ON",
+    }
+    cache_path = args.abiss_home / "build" / "CMakeCache.txt"
+    if not cache_path.is_file():
+        raise FileNotFoundError(f"ABISS build is missing its CMake cache: {cache_path}")
+    cache = _cmake_cache(cache_path)
+    mismatches = {
+        key: {"actual": cache.get(key), "expected": expected}
+        for key, expected in expected_toolchain.items()
+        if cache.get(key) != expected
+    }
+    if mismatches:
+        raise RuntimeError(f"ABISS toolchain mismatch: {mismatches}")
+    binary_dependencies = {
+        name: _dynamic_dependencies(args.abiss_home / "build" / name) for name in ("ws", "agg")
+    }
+    for name, dependencies in binary_dependencies.items():
+        if "libtbb.so.12" not in dependencies:
+            raise RuntimeError(f"ABISS {name} requires {dependencies}; expected libtbb.so.12")
+        incompatible = [
+            dependency
+            for dependency in dependencies
+            if dependency == "libtbb.so.2" or ".so.1.85.0" in dependency
+        ]
+        if incompatible:
+            raise RuntimeError(
+                f"ABISS {name} has incompatible runtime dependencies: {incompatible}"
+            )
 
     index = json.loads(args.affinity_index.read_text(encoding="utf-8"))
     chunks = index.get("chunks", [])
@@ -170,8 +227,7 @@ def main() -> int:
     )
     if covered_shape != EXPECTED_COVERAGE_SHAPE_ZYX:
         raise RuntimeError(
-            f"Affinity covered shape is {covered_shape}, "
-            f"expected {EXPECTED_COVERAGE_SHAPE_ZYX}"
+            f"Affinity covered shape is {covered_shape}, " f"expected {EXPECTED_COVERAGE_SHAPE_ZYX}"
         )
 
     with ThreadPoolExecutor(max_workers=args.workers) as executor:
@@ -217,6 +273,10 @@ def main() -> int:
         "abiss_commit": abiss_head,
         "abiss_binaries_sha256": {
             name: _sha256(args.abiss_home / "build" / name) for name in ("ws", "agg")
+        },
+        "abiss_toolchain": {
+            "cmake": {key: cache[key] for key in expected_toolchain},
+            "dynamic_dependencies": binary_dependencies,
         },
         "environment": {
             "python": platform.python_version(),

--- a/tutorials/neuron_j0126/reproduction/preflight.py
+++ b/tutorials/neuron_j0126/reproduction/preflight.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Fail-closed preflight for the frozen j0126 reproduction inputs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import platform
+import shutil
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import h5py
+
+
+EXPECTED_ABISS_COMMIT = "452efa5f87f9d3cb241891ee44010d966a33b316"
+EXPECTED_BBOX_XYZ = (0, 0, 0, 10664, 10912, 5700)
+EXPECTED_INDEX_SHAPE_ZYX = (5700, 12288, 12288)
+EXPECTED_COVERAGE_SHAPE_ZYX = (5700, 10913, 10664)
+EXPECTED_KEEP_MASK_SHAPE_ZYX = (5700, 10912, 10664)
+EXPECTED_NUCLEUS_SHAPE_ZYX = (1425, 1365, 1333)
+EXPECTED_GRID_ZYX = (6, 11, 11)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _check_chunk(index_dir: Path, entry: dict[str, Any]) -> dict[str, Any]:
+    path = index_dir / entry["path"]
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    expected_spatial = tuple(
+        int(stop) - int(start)
+        for start, stop in zip(entry["start_zyx"], entry["stop_zyx"])
+    )
+    with h5py.File(path, "r", locking=False) as handle:
+        if "main" not in handle:
+            raise ValueError(f"{path}: missing dataset 'main'")
+        dataset = handle["main"]
+        expected_shape = (3, *expected_spatial)
+        if tuple(dataset.shape) != expected_shape:
+            raise ValueError(f"{path}: shape {dataset.shape}, expected {expected_shape}")
+        if str(dataset.dtype) != "float16":
+            raise ValueError(f"{path}: dtype {dataset.dtype}, expected float16")
+    return {"path": str(path), "bytes": path.stat().st_size}
+
+
+def _load_zarr_v3_shape(path: Path) -> tuple[int, ...]:
+    metadata = json.loads((path / "zarr.json").read_text(encoding="utf-8"))
+    return tuple(int(value) for value in metadata["shape"])
+
+
+def _git_head(path: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _git_tracked_status(path: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(path), "status", "--porcelain", "--untracked-files=no"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _package_versions() -> dict[str, str]:
+    versions = {}
+    for distribution in (
+        "cloud-volume",
+        "h5py",
+        "networkx",
+        "numpy",
+        "PyYAML",
+        "scipy",
+        "zarr",
+    ):
+        try:
+            versions[distribution] = importlib.metadata.version(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            versions[distribution] = "not installed"
+    return versions
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--affinity-chunks", type=Path, required=True)
+    parser.add_argument("--affinity-index", type=Path, required=True)
+    parser.add_argument("--keep-mask", type=Path, required=True)
+    parser.add_argument("--nucleus", type=Path, required=True)
+    parser.add_argument("--skeletons", type=Path, required=True)
+    parser.add_argument("--abiss-home", type=Path, required=True)
+    parser.add_argument("--storage-root", type=Path, required=True)
+    parser.add_argument("--min-free-tib", type=float, default=8.0)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    for path in (
+        args.affinity_chunks,
+        args.affinity_index,
+        args.keep_mask,
+        args.nucleus,
+        args.skeletons,
+        args.abiss_home,
+        args.storage_root,
+    ):
+        if not path.exists():
+            raise FileNotFoundError(path)
+
+    abiss_head = _git_head(args.abiss_home)
+    if abiss_head != EXPECTED_ABISS_COMMIT:
+        raise RuntimeError(
+            f"ABISS is {abiss_head}; frozen result requires {EXPECTED_ABISS_COMMIT}"
+        )
+    tracked_status = _git_tracked_status(args.abiss_home)
+    if tracked_status:
+        raise RuntimeError(
+            "ABISS has tracked modifications; frozen replay requires a clean checkout:\n"
+            + tracked_status
+        )
+    for relative in ("build/ws", "build/agg", "scripts/nucleus_competition.py"):
+        path = args.abiss_home / relative
+        if not path.is_file():
+            raise FileNotFoundError(f"ABISS runtime is incomplete: {path}")
+
+    index = json.loads(args.affinity_index.read_text(encoding="utf-8"))
+    chunks = index.get("chunks", [])
+    if int(index.get("world_size", -1)) != 726 or len(chunks) != 726:
+        raise RuntimeError(
+            f"Affinity index has world_size={index.get('world_size')} and "
+            f"{len(chunks)} chunks; expected 726"
+        )
+    keys = {tuple(int(value) for value in entry["index_zyx"]) for entry in chunks}
+    expected_keys = {
+        (z, y, x)
+        for z in range(EXPECTED_GRID_ZYX[0])
+        for y in range(EXPECTED_GRID_ZYX[1])
+        for x in range(EXPECTED_GRID_ZYX[2])
+    }
+    if keys != expected_keys:
+        missing = sorted(expected_keys - keys)
+        extra = sorted(keys - expected_keys)
+        raise RuntimeError(f"Affinity grid mismatch; missing={missing[:5]}, extra={extra[:5]}")
+    final_shape = tuple(int(value) for value in index["final_shape"])
+    if final_shape != EXPECTED_INDEX_SHAPE_ZYX:
+        raise RuntimeError(
+            f"Affinity index shape is {final_shape}, expected {EXPECTED_INDEX_SHAPE_ZYX}"
+        )
+    covered_shape = tuple(
+        max(int(entry["stop_zyx"][axis]) for entry in chunks) for axis in range(3)
+    )
+    if covered_shape != EXPECTED_COVERAGE_SHAPE_ZYX:
+        raise RuntimeError(
+            f"Affinity covered shape is {covered_shape}, "
+            f"expected {EXPECTED_COVERAGE_SHAPE_ZYX}"
+        )
+
+    with ThreadPoolExecutor(max_workers=args.workers) as executor:
+        checked = list(
+            executor.map(
+                lambda entry: _check_chunk(args.affinity_index.parent, entry),
+                chunks,
+            )
+        )
+
+    keep_shape = _load_zarr_v3_shape(args.keep_mask)
+    if keep_shape != EXPECTED_KEEP_MASK_SHAPE_ZYX:
+        raise RuntimeError(
+            f"Keep-mask shape is {keep_shape}, expected {EXPECTED_KEEP_MASK_SHAPE_ZYX}"
+        )
+
+    with h5py.File(args.nucleus, "r", locking=False) as handle:
+        nucleus = handle["main"]
+        nucleus_shape = tuple(int(value) for value in nucleus.shape)
+        nucleus_dtype = str(nucleus.dtype)
+    if nucleus_shape != EXPECTED_NUCLEUS_SHAPE_ZYX or nucleus_dtype != "uint16":
+        raise RuntimeError(
+            f"Nucleus volume is {nucleus_shape} {nucleus_dtype}; expected "
+            f"{EXPECTED_NUCLEUS_SHAPE_ZYX} uint16"
+        )
+
+    with h5py.File(args.skeletons, "r", locking=False) as handle:
+        skeleton_count = len(handle)
+        skeleton_nodes = sum(int(handle[key]["vertices"].shape[0]) for key in handle)
+    if skeleton_count != 50:
+        raise RuntimeError(f"Skeleton file has {skeleton_count} groups; expected 50")
+
+    usage = shutil.disk_usage(args.storage_root)
+    free_tib = usage.free / 2**40
+    if free_tib < args.min_free_tib:
+        raise RuntimeError(
+            f"Only {free_tib:.2f} TiB free at {args.storage_root}; "
+            f"require at least {args.min_free_tib:.2f} TiB"
+        )
+
+    report = {
+        "status": "pass",
+        "abiss_commit": abiss_head,
+        "abiss_binaries_sha256": {
+            name: _sha256(args.abiss_home / "build" / name) for name in ("ws", "agg")
+        },
+        "environment": {
+            "python": platform.python_version(),
+            "packages": _package_versions(),
+        },
+        "bbox_xyz": list(EXPECTED_BBOX_XYZ),
+        "affinity": {
+            "chunks": len(checked),
+            "grid_zyx": list(EXPECTED_GRID_ZYX),
+            "index_shape_zyx": list(final_shape),
+            "covered_shape_zyx": list(covered_shape),
+            "bytes": sum(item["bytes"] for item in checked),
+            "index_sha256": _sha256(args.affinity_index),
+        },
+        "keep_mask_shape_zyx": list(keep_shape),
+        "nucleus": {"shape_zyx": list(nucleus_shape), "dtype": nucleus_dtype},
+        "skeletons": {"count": skeleton_count, "nodes": skeleton_nodes},
+        "storage": {"root": str(args.storage_root), "free_tib": free_tib},
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tutorials/neuron_j0126/reproduction/prepare.py
+++ b/tutorials/neuron_j0126/reproduction/prepare.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Prepare restartable sharded ABISS task lists without running the chunks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPOSITORY = Path(__file__).resolve().parents[3]
+for import_path in (REPOSITORY, REPOSITORY / "scripts"):
+    if str(import_path) not in sys.path:
+        sys.path.insert(0, str(import_path))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--out-root", type=Path, required=True)
+    parser.add_argument("--runtime-json", type=Path, required=True)
+    parser.add_argument("--mode", choices=("fresh", "resume"), default="fresh")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    import run_seuron_provenance as replay
+    from connectomics.runtime.abiss_chunk import (
+        _prepare_execution_outputs,
+        _prepare_runtime_secrets_view,
+        _write_param,
+    )
+
+    cli_args = replay.parse_args(
+        [
+            "--config",
+            str(args.config),
+            "--name",
+            args.name,
+            "--out-root",
+            str(args.out_root),
+            "--mode",
+            args.mode,
+            "--execute",
+        ]
+    )
+    resolved = replay.resolve_replay(cli_args)
+    replay._preflight_abiss(resolved)
+    replay._preflight_nucleus(resolved)
+    affinity = replay._preflight_affinity(resolved)
+    build_id = replay._abiss_build_id(resolved.abiss_home)
+    expected_manifest = replay._expected_manifest(resolved, abiss_build_id=build_id)
+    replay._apply_output_mode(resolved, expected_manifest)
+    replay._write_manifest(resolved, expected_manifest)
+
+    prepared = replay.prepare_execution(resolved, affinity)
+    _prepare_execution_outputs(prepared)
+    _prepare_runtime_secrets_view(prepared)
+    _write_param(prepared.param_path, prepared.param_payload)
+    runtime_param = prepared.effective_secrets_dir / "param"
+    _write_param(runtime_param, prepared.param_payload)
+
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "WORKER_HOME": str(prepared.abiss_home),
+            "SECRETS": str(prepared.effective_secrets_dir),
+            "STAGE": "ws",
+            "AIRFLOW_TMP_DIR": str(prepared.workdir / ".airflow_init"),
+        }
+    )
+    environment.update(prepared.extra_env or {})
+    scripts = prepared.abiss_home / "scripts"
+    prepared.workdir.mkdir(parents=True, exist_ok=True)
+
+    config_sh = prepared.effective_secrets_dir / "config.sh"
+    temporary_config = config_sh.with_suffix(".sh.tmp")
+    with temporary_config.open("w", encoding="utf-8") as handle:
+        subprocess.run(
+            [sys.executable, str(scripts / "set_env.py"), str(runtime_param)],
+            stdout=handle,
+            cwd=prepared.workdir,
+            env=environment,
+            check=True,
+        )
+    temporary_config.replace(config_sh)
+
+    for script_name in ("chunk_volume.py", "generate_batches.py"):
+        subprocess.run(
+            [sys.executable, str(scripts / script_name), prepared.root_tag, str(runtime_param)],
+            cwd=prepared.workdir,
+            env=environment,
+            check=True,
+        )
+
+    layers = {}
+    for layer in range(prepared.top_mip + 1):
+        task_file = prepared.workdir / f"{layer}.txt"
+        if task_file.is_file():
+            layers[layer] = sum(bool(line.strip()) for line in task_file.read_text().splitlines())
+    runtime = {
+        "repository": str(REPOSITORY),
+        "workdir": str(prepared.workdir),
+        "abiss_home": str(prepared.abiss_home),
+        "secrets": str(prepared.effective_secrets_dir),
+        "cloud_volume_dir": (prepared.extra_env or {}).get("CLOUD_VOLUME_DIR", ""),
+        "param": str(runtime_param),
+        "root_tag": prepared.root_tag,
+        "top_mip": prepared.top_mip,
+        "layers": layers,
+        "seg_path": str(prepared.param_payload["SEG_PATH"]),
+    }
+    args.runtime_json.parent.mkdir(parents=True, exist_ok=True)
+    args.runtime_json.write_text(json.dumps(runtime, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(runtime, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tutorials/neuron_j0126/reproduction/seuron_provenance.json
+++ b/tutorials/neuron_j0126/reproduction/seuron_provenance.json
@@ -1,0 +1,34 @@
+{
+  "description": "Frozen j0126 ABISS segmentation parameters used by the PyTC2 table.",
+  "owners": [],
+  "processing": [
+    {
+      "by": "ranl",
+      "date": "2026-07-19 06:57 UTC",
+      "method": {
+        "AFF_MIP": 0,
+        "AFF_PATH": "gs://zebrafinch_aff1/affinity_r1_float32/",
+        "AFF_RESOLUTION": [9, 9, 20],
+        "AGG_THRESHOLD": "0.3",
+        "BBOX": [0, 0, 0, 10664, 10912, 5700],
+        "CHUNKMAP_OUTPUT": "gs://unused-by-local-replay/chunkmap",
+        "CHUNK_SIZE": [512, 512, 256],
+        "IMAGE_PATH": "gs://j0126-nature-methods-data/GgwKmcKgrcoNxJccKuGIzRnQqfit9hnfK1ctZzNbnuU/rawdata_realigned/",
+        "NAME": "seg_20260719054914",
+        "NG_PREFIX": "gs://unused-by-local-replay/precomputed/",
+        "SCRATCH_PATH": "gs://unused-by-local-replay/scratch",
+        "SCRATCH_PREFIX": "gs://unused-by-local-replay/",
+        "SEG_PATH": "gs://unused-by-local-replay/seg",
+        "SEG_PREFIX": "gs://unused-by-local-replay/",
+        "SKIP_SKELETON": true,
+        "WS_DUST_THRESHOLD": "200",
+        "WS_HIGH_THRESHOLD": "0.99999",
+        "WS_LOW_THRESHOLD": "0.00001",
+        "WS_PATH": "gs://unused-by-local-replay/ws",
+        "WS_PREFIX": "gs://unused-by-local-replay/",
+        "WS_SIZE_THRESHOLD": "200"
+      }
+    }
+  ],
+  "sources": []
+}

--- a/tutorials/neuron_j0126/reproduction/slurm/00_build_abiss.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/00_build_abiss.sbatch
@@ -12,9 +12,22 @@ set -euo pipefail
 : "${ABISS_HOME:?Set ABISS_HOME to the pinned ABISS checkout}"
 : "${PYTC_PREFIX:?Set PYTC_PREFIX to the pytc conda environment}"
 
-# Compute nodes expose compiler wrappers through ccache, while their inherited
-# XDG runtime directory can be owned by another node. Keep all ccache writes in
-# the writeable checkout so configuration does not fail before compilation.
+# The frozen reference was built with the conda compiler, Boost 1.82, and
+# oneTBB (libtbb.so.12). Merely setting CMAKE_PREFIX_PATH is not sufficient:
+# CMake may otherwise select the host compiler, Boost 1.85, and legacy
+# libtbb.so.2, which produces a binary that fails or stalls during mean-edge
+# agglomeration.
+cc="$PYTC_PREFIX/bin/x86_64-conda-linux-gnu-cc"
+cxx="$PYTC_PREFIX/bin/x86_64-conda-linux-gnu-c++"
+boost_dir="$PYTC_PREFIX/lib/cmake/Boost-1.82.0"
+tbb_dir="$PYTC_PREFIX/lib/cmake/TBB"
+for required in "$cc" "$cxx" "$boost_dir/BoostConfig.cmake" "$tbb_dir/TBBConfig.cmake"; do
+  if [ ! -e "$required" ]; then
+    echo "Missing frozen-toolchain dependency: $required" >&2
+    exit 2
+  fi
+done
+
 export CCACHE_DIR="$ABISS_HOME/.ccache"
 export CCACHE_TEMPDIR="$ABISS_HOME/.ccache/tmp"
 export CMAKE_PREFIX_PATH="$PYTC_PREFIX${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
@@ -30,10 +43,53 @@ fi
 
 cmake -S "$ABISS_HOME" -B "$ABISS_HOME/build" \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER="$cc" \
+  -DCMAKE_CXX_COMPILER="$cxx" \
   -DBOOST_ROOT="$PYTC_PREFIX" \
+  -DBoost_DIR="$boost_dir" \
+  -DTBB_DIR="$tbb_dir" \
+  -DEXTRACT_SIZE=ON \
   -DBUILD_TESTING=ON
 cmake --build "$ABISS_HOME/build" --parallel "${SLURM_CPUS_PER_TASK:-8}"
 ctest --test-dir "$ABISS_HOME/build" --output-on-failure
 
+cache="$ABISS_HOME/build/CMakeCache.txt"
+require_cache_value() {
+  local key=$1 expected_value=$2
+  if ! awk -v key="$key" -v expected="$expected_value" '
+    index($0, key ":") == 1 {
+      separator = index($0, "=")
+      if (separator && substr($0, separator + 1) == expected) found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$cache"; then
+    echo "CMake cache does not pin ${key}=${expected_value}" >&2
+    grep -E "^${key}:" "$cache" >&2 || true
+    exit 3
+  fi
+}
+require_cache_value CMAKE_C_COMPILER "$cc"
+require_cache_value CMAKE_CXX_COMPILER "$cxx"
+require_cache_value Boost_DIR "$boost_dir"
+require_cache_value TBB_DIR "$tbb_dir"
+require_cache_value EXTRACT_SIZE ON
+
+for binary in ws agg; do
+  dynamic=$(readelf -d "$ABISS_HOME/build/$binary")
+  if ! grep -Fq 'Shared library: [libtbb.so.12]' <<<"$dynamic"; then
+    echo "$binary is not linked to the frozen oneTBB soname libtbb.so.12" >&2
+    exit 4
+  fi
+  if grep -Eq 'libtbb\.so\.2]|libboost_.*\.so\.1\.85\.0]' <<<"$dynamic"; then
+    echo "$binary picked up an incompatible system/Boost runtime" >&2
+    grep 'Shared library:' <<<"$dynamic" >&2
+    exit 4
+  fi
+done
+
 git -C "$ABISS_HOME" status --short --branch
+sha256sum "$ABISS_HOME/build/ws" "$ABISS_HOME/build/agg"
+"$cxx" --version | head -1
+grep -E '^(CMAKE_CXX_COMPILER|Boost_DIR|TBB_DIR):' "$cache"
+readelf -d "$ABISS_HOME/build/agg" | grep -E 'NEEDED|RPATH|RUNPATH'
 echo "ABISS build complete: $ABISS_HOME/build"

--- a/tutorials/neuron_j0126/reproduction/slurm/00_build_abiss.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/00_build_abiss.sbatch
@@ -1,0 +1,39 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-build
+#SBATCH --partition=short
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=02:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${ABISS_HOME:?Set ABISS_HOME to the pinned ABISS checkout}"
+: "${PYTC_PREFIX:?Set PYTC_PREFIX to the pytc conda environment}"
+
+# Compute nodes expose compiler wrappers through ccache, while their inherited
+# XDG runtime directory can be owned by another node. Keep all ccache writes in
+# the writeable checkout so configuration does not fail before compilation.
+export CCACHE_DIR="$ABISS_HOME/.ccache"
+export CCACHE_TEMPDIR="$ABISS_HOME/.ccache/tmp"
+export CMAKE_PREFIX_PATH="$PYTC_PREFIX${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+export LD_LIBRARY_PATH="$PYTC_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+mkdir -p "$CCACHE_TEMPDIR"
+
+head=$(git -C "$ABISS_HOME" rev-parse HEAD)
+expected=452efa5f87f9d3cb241891ee44010d966a33b316
+if [ "$head" != "$expected" ]; then
+  echo "ABISS commit $head does not match frozen commit $expected" >&2
+  exit 2
+fi
+
+cmake -S "$ABISS_HOME" -B "$ABISS_HOME/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBOOST_ROOT="$PYTC_PREFIX" \
+  -DBUILD_TESTING=ON
+cmake --build "$ABISS_HOME/build" --parallel "${SLURM_CPUS_PER_TASK:-8}"
+ctest --test-dir "$ABISS_HOME/build" --output-on-failure
+
+git -C "$ABISS_HOME" status --short --branch
+echo "ABISS build complete: $ABISS_HOME/build"

--- a/tutorials/neuron_j0126/reproduction/slurm/00_validate_agg.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/00_validate_agg.sbatch
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-agg-check
+#SBATCH --partition=medium
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=32G
+#SBATCH --time=02:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${SOURCE_CHUNK:?Set SOURCE_CHUNK to a failed atomic mean-edge work directory}"
+: "${VALIDATION_DIR:?Set VALIDATION_DIR to a new output directory}"
+: "${ABISS_HOME:?Set ABISS_HOME to the rebuilt pinned checkout}"
+: "${ABISS_LIBRARY_PREFIX:?Set ABISS_LIBRARY_PREFIX to the pinned conda environment}"
+
+if [ -e "$VALIDATION_DIR" ]; then
+  echo "Refusing to reuse validation directory: $VALIDATION_DIR" >&2
+  exit 2
+fi
+mkdir -p "$VALIDATION_DIR"
+
+for name in aff.raw seg.raw chunkmap.data param.txt; do
+  if [ ! -f "$SOURCE_CHUNK/$name" ]; then
+    echo "Missing validation input: $SOURCE_CHUNK/$name" >&2
+    exit 2
+  fi
+  cp --reflink=auto "$SOURCE_CHUNK/$name" "$VALIDATION_DIR/$name"
+done
+
+export LD_LIBRARY_PATH="$ABISS_LIBRARY_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export OMP_NUM_THREADS=1
+cd "$VALIDATION_DIR"
+mkdir chunked_rg
+
+sha256sum "$ABISS_HOME/build/agg" > binary.sha256
+readelf -d "$ABISS_HOME/build/agg" | grep -E 'NEEDED|RPATH|RUNPATH' > binary.dynamic.txt
+chunk_tag=$(basename "$SOURCE_CHUNK")
+/usr/bin/time -v "$ABISS_HOME/build/acme" param.txt "$chunk_tag" \
+  > acme.stdout.txt 2> acme.stderr.txt
+
+mv "edges_${chunk_tag}.data" input_rg.data
+cat boundary_*_"${chunk_tag}".data > frozen.data
+test -s ns.data
+test -s ongoing_seg_size.data
+touch ongoing_semantic_labels.data ongoing_nuclei_labels.data
+/usr/bin/time -v "$ABISS_HOME/build/agg" "${AGG_THRESHOLD:-0.3}" \
+  input_rg.data frozen.data ns.data > agg.stdout.txt 2> agg.stderr.txt
+
+test -s residual_rg.data
+test -s remap.data
+touch SUCCESS
+echo "Pinned ABISS agg completed the regression chunk: $VALIDATION_DIR"

--- a/tutorials/neuron_j0126/reproduction/slurm/01_preflight.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/01_preflight.sbatch
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-preflight
+#SBATCH --partition=short
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=04:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${REPOSITORY:?}"
+: "${PYTHON:?}"
+: "${AFFINITY_CHUNKS:?}"
+: "${AFFINITY_INDEX:?}"
+: "${KEEP_MASK:?}"
+: "${NUCLEUS:?}"
+: "${SKELETONS:?}"
+: "${ABISS_HOME:?}"
+: "${STORAGE_ROOT:?}"
+: "${PREFLIGHT_JSON:?}"
+
+export HDF5_USE_FILE_LOCKING=FALSE
+cd "$REPOSITORY"
+exec "$PYTHON" \
+  tutorials/neuron_j0126/reproduction/preflight.py \
+  --affinity-chunks "$AFFINITY_CHUNKS" \
+  --affinity-index "$AFFINITY_INDEX" \
+  --keep-mask "$KEEP_MASK" \
+  --nucleus "$NUCLEUS" \
+  --skeletons "$SKELETONS" \
+  --abiss-home "$ABISS_HOME" \
+  --storage-root "$STORAGE_ROOT" \
+  --output "$PREFLIGHT_JSON" \
+  --workers "${SLURM_CPUS_PER_TASK:-8}"

--- a/tutorials/neuron_j0126/reproduction/slurm/01_preflight.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/01_preflight.sbatch
@@ -17,6 +17,7 @@ set -euo pipefail
 : "${NUCLEUS:?}"
 : "${SKELETONS:?}"
 : "${ABISS_HOME:?}"
+: "${PYTC_PREFIX:?}"
 : "${STORAGE_ROOT:?}"
 : "${PREFLIGHT_JSON:?}"
 
@@ -30,6 +31,7 @@ exec "$PYTHON" \
   --nucleus "$NUCLEUS" \
   --skeletons "$SKELETONS" \
   --abiss-home "$ABISS_HOME" \
+  --pytc-prefix "$PYTC_PREFIX" \
   --storage-root "$STORAGE_ROOT" \
   --output "$PREFLIGHT_JSON" \
   --workers "${SLURM_CPUS_PER_TASK:-8}"

--- a/tutorials/neuron_j0126/reproduction/slurm/02_smoke.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/02_smoke.sbatch
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-smoke
+#SBATCH --partition=short
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=12:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${REPOSITORY:?}"
+: "${PYTHON:?}"
+: "${CONFIG:?}"
+: "${OUT_ROOT:?}"
+: "${RUN_NAME:?}"
+
+# Frozen ABISS derives its ID namespace and hierarchy from the full-volume
+# geometry. Cropped multi-chunk boxes can therefore fail in later RAG stages
+# even when watershed succeeds. A single native chunk at the origin is the
+# reliable binary/runtime smoke; the full-volume regression is the semantic
+# gate for hierarchy composition.
+read -r -a bbox <<<"${BBOX_XYZ:-0 0 0 512 512 256}"
+if [ "${#bbox[@]}" -ne 6 ]; then
+  echo "BBOX_XYZ must contain six integers" >&2
+  exit 2
+fi
+
+export HDF5_USE_FILE_LOCKING=FALSE
+cd "$REPOSITORY"
+exec "$PYTHON" scripts/run_seuron_provenance.py \
+  --config "$CONFIG" \
+  --out-root "$OUT_ROOT" \
+  --name "$RUN_NAME" \
+  --exec-bbox "${bbox[@]}" \
+  --mode fresh \
+  --stages watershed remap_watershed \
+  --execute

--- a/tutorials/neuron_j0126/reproduction/slurm/03_prepare_full.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/03_prepare_full.sbatch
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-prepare
+#SBATCH --partition=short
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=12:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${REPOSITORY:?}"
+: "${PYTHON:?}"
+: "${CONFIG:?}"
+: "${OUT_ROOT:?}"
+: "${RUN_NAME:?}"
+: "${RUNTIME_JSON:?}"
+
+export HDF5_USE_FILE_LOCKING=FALSE
+cd "$REPOSITORY"
+exec "$PYTHON" tutorials/neuron_j0126/reproduction/prepare.py \
+  --config "$CONFIG" \
+  --out-root "$OUT_ROOT" \
+  --name "$RUN_NAME" \
+  --runtime-json "$RUNTIME_JSON" \
+  --mode "${RUN_MODE:-fresh}"

--- a/tutorials/neuron_j0126/reproduction/slurm/04_abiss_shard.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/04_abiss_shard.sbatch
@@ -1,0 +1,58 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-shard
+#SBATCH --partition=medium
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --time=12:00:00
+#SBATCH --output=slurm-%x-%A_%a.out
+
+set -euo pipefail
+: "${RUNTIME_JSON:?}"
+: "${PYTHON:?}"
+: "${ABISS_LIBRARY_PREFIX:?}"
+: "${OP:?}"
+: "${LAYER:?}"
+: "${STAGE_ENV:?}"
+
+export PATH="$(dirname "$PYTHON"):$PATH"
+export LD_LIBRARY_PATH="$ABISS_LIBRARY_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export HDF5_USE_FILE_LOCKING=FALSE
+
+read_runtime() {
+  "$PYTHON" -c "import json; print(json.load(open('$RUNTIME_JSON'))['$1'])"
+}
+
+workdir=$(read_runtime workdir)
+abiss_home=$(read_runtime abiss_home)
+secrets=$(read_runtime secrets)
+cloud_volume_dir=$(read_runtime cloud_volume_dir)
+shards=${NSHARD:-1}
+shard=${SLURM_ARRAY_TASK_ID:-0}
+cpus=${SLURM_CPUS_PER_TASK:-1}
+
+export WORKER_HOME="$abiss_home"
+export SECRETS="$secrets"
+export STAGE="$STAGE_ENV"
+export OVERLAP="${OVERLAP:-0}"
+export META="${META:-}"
+if [ -n "$cloud_volume_dir" ]; then
+  export CLOUD_VOLUME_DIR="$cloud_volume_dir"
+fi
+export AIRFLOW_TMP_DIR="$workdir/.airflow_${SLURM_ARRAY_JOB_ID:-$SLURM_JOB_ID}_$shard"
+mkdir -p "$AIRFLOW_TMP_DIR"
+rm -f "$AIRFLOW_TMP_DIR"/.cpulock_*
+
+cd "$workdir"
+task_list=".shard_${OP}_L${LAYER}_${shard}of${shards}.txt"
+awk -v n="$shards" -v s="$shard" 'NR % n == s' "${LAYER}.txt" > "$task_list"
+task_count=$(wc -l < "$task_list")
+echo "shard=$shard/$shards op=$OP layer=$LAYER tasks=$task_count cpus=$cpus host=$(hostname)"
+if [ "$task_count" -eq 0 ]; then
+  exit 0
+fi
+
+export TMPDIR="$AIRFLOW_TMP_DIR/parallel"
+mkdir -p "$TMPDIR"
+parallel --halt 2 -j "$cpus" --tmpdir "$TMPDIR" --compress \
+  "$abiss_home/scripts/run_wrapper.sh" . "$OP" {} < "$task_list"
+echo "complete shard=$shard/$shards op=$OP layer=$LAYER"

--- a/tutorials/neuron_j0126/reproduction/slurm/04_nucleus_competition.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/04_nucleus_competition.sbatch
@@ -1,0 +1,34 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-nucleus
+#SBATCH --partition=long
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=192G
+#SBATCH --time=2-00:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${RUNTIME_JSON:?}"
+: "${PYTHON:?}"
+: "${ABISS_LIBRARY_PREFIX:?}"
+
+export PATH="$(dirname "$PYTHON"):$PATH"
+export LD_LIBRARY_PATH="$ABISS_LIBRARY_PREFIX/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export HDF5_USE_FILE_LOCKING=FALSE
+abiss_home=$("$PYTHON" -c \
+  "import json; print(json.load(open('$RUNTIME_JSON'))['abiss_home'])")
+param=$("$PYTHON" -c \
+  "import json; print(json.load(open('$RUNTIME_JSON'))['param'])")
+cloud_volume_dir=$("$PYTHON" -c \
+  "import json; print(json.load(open('$RUNTIME_JSON'))['cloud_volume_dir'])")
+if [ -n "$cloud_volume_dir" ]; then
+  export CLOUD_VOLUME_DIR="$cloud_volume_dir"
+fi
+export PARAM_JSON="$param"
+
+"$PYTHON" -u "$abiss_home/scripts/nucleus_competition.py" "$param"
+manifest=$("$PYTHON" -c \
+  "import json; print(json.load(open('$param'))['NUC_COMPETITION_MANIFEST'])")
+"$PYTHON" -c \
+  "import json; p=json.load(open('$manifest')); assert p['manifest_type']=='abiss_nucleus_competition'; print(f\"verified {len(p['repairs'])} nucleus repairs\")"

--- a/tutorials/neuron_j0126/reproduction/slurm/05_evaluate.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/05_evaluate.sbatch
@@ -1,0 +1,33 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-eval
+#SBATCH --partition=short
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=90G
+#SBATCH --time=08:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${REPOSITORY:?}"
+: "${PYTHON:?}"
+: "${SKELETONS:?}"
+: "${EVALUATION_JSON:?}"
+if [ -n "${SEGMENTATION:-}" ] && [ -n "${NODE_LUT:-}" ]; then
+  echo "set only one of SEGMENTATION or NODE_LUT" >&2
+  exit 2
+elif [ -n "${SEGMENTATION:-}" ]; then
+  source_args=(--segmentation "$SEGMENTATION")
+elif [ -n "${NODE_LUT:-}" ]; then
+  source_args=(--node-lut "$NODE_LUT")
+else
+  echo "SEGMENTATION or NODE_LUT is required" >&2
+  exit 2
+fi
+
+export HDF5_USE_FILE_LOCKING=FALSE
+cd "$REPOSITORY"
+exec "$PYTHON" tutorials/neuron_j0126/reproduction/evaluate.py \
+  "${source_args[@]}" \
+  --skeletons "$SKELETONS" \
+  --output "$EVALUATION_JSON"

--- a/tutorials/neuron_j0126/reproduction/slurm/05_ffn_native_lut.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/05_ffn_native_lut.sbatch
@@ -1,0 +1,39 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-ffn-mip0
+#SBATCH --partition=medium
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=2-00:00:00
+#SBATCH --output=slurm-%x-%j.out
+
+set -euo pipefail
+: "${REPOSITORY:?}"
+: "${PYTHON:?}"
+: "${EM_ERL_HOME:?}"
+: "${SKELETONS:?}"
+: "${NODE_LUT:?}"
+: "${ERL_PICKLE:?}"
+: "${EVALUATION_JSON:?}"
+
+mkdir -p "$(dirname "$NODE_LUT")" "$(dirname "$ERL_PICKLE")" \
+  "$(dirname "$EVALUATION_JSON")" "${CACHE_DIR:?}"
+export HDF5_USE_FILE_LOCKING=FALSE
+
+cd "$EM_ERL_HOME"
+"$PYTHON" -u examples/eval_j0126.py \
+  --gt-skeleton "$SKELETONS" \
+  --merge-threshold 5 \
+  --num-workers "${SLURM_CPUS_PER_TASK:-16}" \
+  --mip 0 \
+  --cache-dir "$CACHE_DIR" \
+  --lut "$NODE_LUT" \
+  --output-path "$ERL_PICKLE"
+
+cd "$REPOSITORY"
+"$PYTHON" tutorials/neuron_j0126/reproduction/evaluate.py \
+  --node-lut "$NODE_LUT" \
+  --skeletons "$SKELETONS" \
+  --output "$EVALUATION_JSON"
+sha256sum "$NODE_LUT" > "$NODE_LUT.sha256"

--- a/tutorials/neuron_j0126/reproduction/slurm/06_error_correction_stage.sbatch
+++ b/tutorials/neuron_j0126/reproduction/slurm/06_error_correction_stage.sbatch
@@ -1,0 +1,29 @@
+#!/bin/bash
+#SBATCH --job-name=j0126-ec
+#SBATCH --partition=medium
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --output=slurm-%x-%A_%a.out
+
+set -euo pipefail
+: "${REPOSITORY:?}"
+: "${PYTHON:?}"
+: "${CONFIG:?}"
+: "${STAGE:?}"
+
+export HDF5_USE_FILE_LOCKING=FALSE
+cd "$REPOSITORY"
+arguments=(--config "$CONFIG" --stage "$STAGE")
+case "$STAGE" in
+  skeletonize|contacts|postprocess)
+    : "${SLURM_ARRAY_TASK_ID:?}"
+    arguments+=(
+      --task-id "$SLURM_ARRAY_TASK_ID"
+      --num-tasks "${NUM_TASKS:-80}"
+    )
+    ;;
+esac
+if [ "${OVERWRITE:-0}" = 1 ]; then
+  arguments+=(--overwrite)
+fi
+exec "$PYTHON" scripts/run_error_correction.py "${arguments[@]}"

--- a/tutorials/neuron_j0126/reproduction/submit_error_correction.sh
+++ b/tutorials/neuron_j0126/reproduction/submit_error_correction.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${REPOSITORY:?}"
+: "${PYTHON:?}"
+: "${CONFIG:?}"
+: "${RUN_ROOT:?}"
+: "${SKELETONS:?}"
+: "${SEGMENTATION:?Final v7 output segmentation path}"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+runner="$script_dir/slurm/06_error_correction_stage.sbatch"
+dependency=${INIT_DEP:-}
+prefix=${JOB_PREFIX:-j0126ec}
+mkdir -p "$RUN_ROOT/logs"
+submission_log="$RUN_ROOT/submission.tsv"
+printf 'stage\tjob_id\tdependency\tpartition\n' > "$submission_log"
+
+resources() {
+  case "$1" in
+    sizes) echo "medium 8 64G 04:00:00 single" ;;
+    skeletonize) echo "long 8 64G 2-00:00:00 array" ;;
+    skeletons) echo "long 8 240G 2-00:00:00 single" ;;
+    contacts) echo "long 2 64G 1-00:00:00 array" ;;
+    contact_graph) echo "long 8 180G 12:00:00 single" ;;
+    candidates) echo "medium 8 96G 12:00:00 single" ;;
+    junction_scope) echo "medium 4 64G 12:00:00 single" ;;
+    junction_features) echo "long 8 240G 2-00:00:00 single" ;;
+    boundary) echo "medium 8 128G 12:00:00 single" ;;
+    resolve) echo "medium 4 96G 12:00:00 single" ;;
+    prepare_output) echo "short 4 32G 02:00:00 single" ;;
+    postprocess) echo "long 1 16G 1-00:00:00 array" ;;
+    verify) echo "short 4 32G 04:00:00 single" ;;
+    *) return 2 ;;
+  esac
+}
+
+submit_stage() {
+  local stage=$1 partition cpus memory wall mode job_id
+  read -r partition cpus memory wall mode <<<"$(resources "$stage")"
+  local dependency_arg=()
+  local array_arg=()
+  if [ -n "$dependency" ]; then
+    dependency_arg=(--dependency="afterok:$dependency")
+  fi
+  if [ "$mode" = array ]; then
+    array_arg=(--array="0-79%40")
+  fi
+  job_id=$(sbatch --parsable \
+    "${dependency_arg[@]}" \
+    "${array_arg[@]}" \
+    --partition="$partition" \
+    --job-name="${prefix}_${stage}" \
+    --cpus-per-task="$cpus" \
+    --mem="$memory" \
+    --time="$wall" \
+    --output="$RUN_ROOT/logs/%x_%A_%a.out" \
+    --export=ALL,REPOSITORY="$REPOSITORY",PYTHON="$PYTHON",CONFIG="$CONFIG",STAGE="$stage",NUM_TASKS=80 \
+    "$runner")
+  job_id=${job_id%%;*}
+  printf '%s\t%s\t%s\t%s\n' "$stage" "$job_id" "$dependency" "$partition" \
+    >> "$submission_log"
+  echo "$stage -> $job_id${dependency:+ after $dependency}"
+  dependency=$job_id
+}
+
+for stage in \
+  sizes skeletonize skeletons contacts contact_graph candidates junction_scope \
+  junction_features boundary resolve prepare_output postprocess verify; do
+  submit_stage "$stage"
+done
+
+evaluation_job=$(sbatch --parsable \
+  --dependency="afterok:$dependency" \
+  --partition=short \
+  --job-name="${prefix}_eval" \
+  --output="$RUN_ROOT/logs/%x_%j.out" \
+  --export=ALL,REPOSITORY="$REPOSITORY",PYTHON="$PYTHON",SEGMENTATION="$SEGMENTATION",SKELETONS="$SKELETONS",EVALUATION_JSON="$RUN_ROOT/evaluation.json" \
+  "$script_dir/slurm/05_evaluate.sbatch")
+evaluation_job=${evaluation_job%%;*}
+printf '%s\t%s\t%s\t%s\n' evaluate "$evaluation_job" "$dependency" short >> "$submission_log"
+printf '%s\n' "$dependency" > "$RUN_ROOT/final_jobid.txt"
+printf '%s\n' "$evaluation_job" > "$RUN_ROOT/evaluation_jobid.txt"
+echo "error correction -> $dependency; evaluation -> $evaluation_job"

--- a/tutorials/neuron_j0126/reproduction/submit_full.sh
+++ b/tutorials/neuron_j0126/reproduction/submit_full.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+"${BASH_VERSION:+true}" 2>/dev/null || exit 2
+set -euo pipefail
+
+: "${RUNTIME_JSON:?}"
+: "${RUN_ROOT:?}"
+: "${PYTHON:?}"
+: "${ABISS_LIBRARY_PREFIX:?}"
+: "${SKELETONS:?}"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+slurm_dir="$script_dir/slurm"
+partition=${PARTITION:-medium}
+prefix=${JOB_PREFIX:-j0126}
+dependency=${INIT_DEP:-}
+top_mip=$("$PYTHON" -c "import json; print(json.load(open('$RUNTIME_JSON'))['top_mip'])")
+mkdir -p "$RUN_ROOT/logs"
+submission_log="$RUN_ROOT/submission.tsv"
+printf 'stage\tjob_id\tdependency\tpartition\n' > "$submission_log"
+
+layer_resources() {
+  case "$1" in
+    0) echo "80 19 180G" ;;
+    1) echo "24 16 130G" ;;
+    2) echo "16 4 96G" ;;
+    3) echo "14 2 96G" ;;
+    4) echo "8 1 120G" ;;
+    *) echo "1 1 300G" ;;
+  esac
+}
+
+submit_layer() {
+  local name=$1 op=$2 layer=$3 stage_env=$4
+  local shards cpus memory job_id
+  read -r shards cpus memory <<<"$(layer_resources "$layer")"
+  local dependency_arg=()
+  if [ -n "$dependency" ]; then
+    dependency_arg=(--dependency="afterok:$dependency")
+  fi
+  job_id=$(sbatch --parsable "${dependency_arg[@]}" \
+    --partition="$partition" \
+    --job-name="${prefix}_${name}" \
+    --array="0-$((shards - 1))" \
+    --cpus-per-task="$cpus" \
+    --mem="$memory" \
+    --output="$RUN_ROOT/logs/%x_%A_%a.out" \
+    --export=ALL,RUNTIME_JSON="$RUNTIME_JSON",PYTHON="$PYTHON",ABISS_LIBRARY_PREFIX="$ABISS_LIBRARY_PREFIX",OP="$op",LAYER="$layer",STAGE_ENV="$stage_env",NSHARD="$shards" \
+    "$slurm_dir/04_abiss_shard.sbatch")
+  job_id=${job_id%%;*}
+  printf '%s\t%s\t%s\t%s\n' "$name" "$job_id" "$dependency" "$partition" \
+    >> "$submission_log"
+  echo "$name -> $job_id${dependency:+ after $dependency}"
+  dependency=$job_id
+}
+
+submit_nucleus() {
+  local enabled nucleus_job dependency_arg=()
+  enabled=$("$PYTHON" -c \
+    "import json; r=json.load(open('$RUNTIME_JSON')); p=json.load(open(r['param'])); print(int(bool(p.get('NUC_PATH')) and p.get('NUC_COMPETITION_ENABLED', True)))")
+  if [ "$enabled" != 1 ]; then
+    echo "nucleus competition disabled"
+    return 0
+  fi
+  if [ -n "$dependency" ]; then
+    dependency_arg=(--dependency="afterok:$dependency")
+  fi
+  nucleus_job=$(sbatch --parsable "${dependency_arg[@]}" \
+    --partition="${NUC_PARTITION:-long}" \
+    --job-name="${prefix}_nucleus" \
+    --output="$RUN_ROOT/logs/%x_%j.out" \
+    --export=ALL,RUNTIME_JSON="$RUNTIME_JSON",PYTHON="$PYTHON",ABISS_LIBRARY_PREFIX="$ABISS_LIBRARY_PREFIX" \
+    "$slurm_dir/04_nucleus_competition.sbatch")
+  nucleus_job=${nucleus_job%%;*}
+  printf '%s\t%s\t%s\t%s\n' nucleus_competition "$nucleus_job" "$dependency" "${NUC_PARTITION:-long}" >> "$submission_log"
+  echo "nucleus_competition -> $nucleus_job${dependency:+ after $dependency}"
+  dependency=$nucleus_job
+}
+
+echo "Submitting $prefix full replay, top_mip=$top_mip, partition=$partition"
+for layer in $(seq 0 "$top_mip"); do
+  operation=composite_chunk_ws
+  if [ "$layer" -eq 0 ]; then operation=atomic_chunk_ws; fi
+  submit_layer "ws${layer}" "$operation" "$layer" ws
+done
+submit_layer remapws remap_chunk_ws 0 ws
+submit_nucleus
+for layer in $(seq 0 "$top_mip"); do
+  operation=composite_chunk_me
+  if [ "$layer" -eq 0 ]; then operation=atomic_chunk_me; fi
+  submit_layer "me${layer}" "$operation" "$layer" agg
+done
+submit_layer remapagg remap_chunk_agg 0 agg
+
+segmentation=$("$PYTHON" -c \
+  "import json; from urllib.parse import unquote; print(unquote(json.load(open('$RUNTIME_JSON'))['seg_path']).removeprefix('file://'))")
+evaluation_job=$(sbatch --parsable \
+  --dependency="afterok:$dependency" \
+  --partition=short \
+  --job-name="${prefix}_eval" \
+  --output="$RUN_ROOT/logs/%x_%j.out" \
+  --export=ALL,REPOSITORY="$("$PYTHON" -c "import json; print(json.load(open('$RUNTIME_JSON'))['repository'])")",PYTHON="$PYTHON",SEGMENTATION="$segmentation",NODE_LUT=,SKELETONS="$SKELETONS",EVALUATION_JSON="$RUN_ROOT/evaluation.json" \
+  "$slurm_dir/05_evaluate.sbatch")
+evaluation_job=${evaluation_job%%;*}
+printf '%s\t%s\t%s\t%s\n' evaluate "$evaluation_job" "$dependency" short >> "$submission_log"
+printf '%s\n' "$dependency" > "$RUN_ROOT/final_decode_jobid.txt"
+printf '%s\n' "$evaluation_job" > "$RUN_ROOT/evaluation_jobid.txt"
+echo "final decode -> $dependency; evaluation -> $evaluation_job"


### PR DESCRIPTION
## Summary
- add a fail-closed, researcher-facing replay for the frozen j0126 Zebrafinch affinity prediction
- reproduce exclusion-only and nucleus-aware ABISS decodes with non-interactive Slurm dependency chains
- add the public mt0/mt5 NERL and background-inclusive/foreground-only VOI evaluator
- pin the frozen ABISS commit, conda compiler, Boost 1.82, oneTBB, and the required `EXTRACT_SIZE=ON` build definition
- document native/mip0 FFN LUT regeneration and binary/input fingerprints

## Verification
- ABISS build: 3/3 tests passed
- focused replay tests: 25/25 passed
- preserved failing atomic mean-edge chunk: corrected `acme` size maps and `agg` completed
- full exclusion replay: NERL mt0 0.267679, mt5 0.469513, VOI 2.583639
- full nucleus-aware replay: 8/8 repairs verified; NERL mt0 0.287184, mt5 0.481614, VOI 2.561970

All volume computation is submitted through the provided `short`, `medium`, or `long` Slurm entry points.